### PR TITLE
Fixes #2; ensure package repo config comes first

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,4 @@
+# Installs the Jenkins package
 class jenkins::install {
 
   class { 'java':
@@ -13,7 +14,10 @@ class jenkins::install {
   }
 
   package { 'jenkins':
-    ensure => $jenkins::version,
+    ensure  => $jenkins::version,
+    require => [
+      Yumrepo['jenkins'],
+    ],
   }
 
 }


### PR DESCRIPTION
This change ensures that the package repository configuration comes
before the package installation attempt, avoiding catalog failures.

Fixes #2.