### PR TITLE
Fixes #4; allow Jenkins in lower ports

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,95 +1,79 @@
+# Configures the Jenkins service
 class jenkins::config {
 
-  augeas {'jenkins_homedir':
+  Augeas {
     context => '/files/etc/sysconfig/jenkins',
+    notify  => Service['jenkins'],
+  }
+
+  augeas { 'jenkins_homedir':
     changes => [ "set JENKINS_HOME '\"${jenkins::homedir}\"'", ],
-    notify  => Service['jenkins']
   }
 
   if $jenkins::java_cmd {
-    augeas {'jenkins_java_cmd':
-      context => '/files/etc/sysconfig/jenkins',
+    augeas { 'jenkins_java_cmd':
       changes => [ "set JENKINS_JAVA_CMD '\"${jenkins::java_cmd}\"'", ],
-      notify  => Service['jenkins']
     }
   }
 
-  augeas {'jenkins_user':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_user':
     changes => [ "set JENKINS_USER '\"${jenkins::user}\"'", ],
-    notify  => Service['jenkins']
   }
 
-  augeas {'jenkins_java_args':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_java_args':
     changes => [ "set JENKINS_JAVA_OPTIONS '\"${jenkins::java_args}\"'", ],
-    notify  => Service['jenkins']
   }
 
-  augeas {'jenkins_http_port':
-    context => '/files/etc/sysconfig/jenkins',
-    changes => [ "set JENKINS_PORT '\"${jenkins::http_port}\"'", ],
-    notify  => Service['jenkins']
+  $real_http_port = $jenkins::use_reserved_ports ? {
+    true    => 80,
+    default => $jenkins::http_port,
+  }
+  augeas { 'jenkins_http_port':
+    changes => [ "set JENKINS_PORT '\"${real_http_port}\"'", ],
   }
 
-  augeas {'jenkins_http_listen_address':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_http_listen_address':
     changes => [ "set JENKINS_LISTEN_ADDRESS '\"${jenkins::http_listen_address}\"'", ],
-    notify  => Service['jenkins']
   }
 
   if $jenkins::enable_https {
-    augeas {'jenkins_https_port':
-      context => '/files/etc/sysconfig/jenkins',
-      changes => [ "set JENKINS_HTTPS_PORT '\"${jenkins::https_port}\"'", ],
-      notify  => Service['jenkins']
+    $real_https_port = $jenkins::use_reserved_ports ? {
+      true    => 443,
+      default => $jenkins::https_port,
     }
-    augeas {'jenkins_https_keystore':
-      context => '/files/etc/sysconfig/jenkins',
+    augeas { 'jenkins_https_port':
+      changes => [ "set JENKINS_HTTPS_PORT '\"${real_https_port}\"'", ],
+    }
+    augeas { 'jenkins_https_keystore':
       changes => [ "set JENKINS_HTTPS_KEYSTORE '\"${jenkins::https_keystore}\"'", ],
-      notify  => Service['jenkins']
     }
-    augeas {'jenkins_https_keystore_password':
-      context => '/files/etc/sysconfig/jenkins',
+    augeas { 'jenkins_https_keystore_password':
       changes => [ "set JENKINS_HTTPS_KEYSTORE_PASSWORD '\"${jenkins::https_keystore_password}\"'", ],
-      notify  => Service['jenkins']
     }
-    augeas {'jenkins_https_listen_address':
-      context => '/files/etc/sysconfig/jenkins',
+    augeas { 'jenkins_https_listen_address':
       changes => [ "set JENKINS_HTTPS_LISTEN_ADDRESS '\"${jenkins::https_listen_address}\"'", ],
-      notify  => Service['jenkins']
     }
   }
 
-  augeas {'jenkins_debug_level':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_debug_level':
     changes => [ "set JENKINS_DEBUG_LEVEL '\"${jenkins::debug}\"'", ],
-    notify  => Service['jenkins']
   }
 
-  augeas {'jenkins_enable_access_log':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_enable_access_log':
     changes => [ "set JENKINS_ENABLE_ACCESS_LOG '\"${jenkins::enable_access_log}\"'", ],
-    notify  => Service['jenkins']
   }
 
-  augeas {'jenkins_handler_max':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_handler_max':
     changes => [ "set JENKINS_HANDLER_MAX '\"${jenkins::handler_max}\"'", ],
-    notify  => Service['jenkins']
   }
 
-  augeas {'jenkins_handler_idle':
-    context => '/files/etc/sysconfig/jenkins',
+  augeas { 'jenkins_handler_idle':
     changes => [ "set JENKINS_HANDLER_IDLE '\"${jenkins::handler_idle}\"'", ],
-    notify  => Service['jenkins']
   }
 
   if $jenkins::args {
-    augeas {'jenkins_args':
-      context => '/files/etc/sysconfig/jenkins',
+    augeas { 'jenkins_args':
       changes => [ "set JENKINS_ARGS '\"${jenkins::args}\"'", ],
-      notify  => Service['jenkins']
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,17 +31,18 @@ class jenkins(
   Integer $handler_max,
   Integer $handler_idle,
   String $java_args,
-  Integer[1024,65535] $http_port,
-  Integer[1024,65535] $https_port,
   String $http_listen_address,
   String $https_listen_address,
   Enum['yes','no'] $enable_access_log,
+  Boolean $use_reserved_ports = false,
+  Integer[1024,65535] $http_port = 8080,
+  Integer[1024,65535] $https_port = 8081,
   Boolean $enable_https    = false,
   $https_keystore          = undef,
   $https_keystore_password = undef,
   $args                    = undef,
   $java_cmd                = undef,
-  ) {
+) {
 
     include jenkins::install
     include jenkins::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,32 @@
 class jenkins::install {
 
+  $java_path = '/usr/lib/jvm/jre-1.8.0'
+
   class { 'java':
     distribution => 'jre',
+  }
+
+  if $jenkins::use_reserved_ports {
+    ldconfig::entry { 'java':
+      paths   => [
+        "${java_path}/lib/amd64/jli",
+        "${java_path}/lib/i386/jli",
+      ],
+      require => [
+        Class['java'],
+      ]
+    }
+
+    # http://man7.org/linux/man-pages/man7/capabilities.7.html
+    file_capability { "${java_path}/bin/java":
+      ensure     => present,
+      capability => [
+        'cap_net_bind_service=epi',
+      ],
+      require    => [
+        Ldconfig::Entry['java'],
+      ],
+    }
   }
 
   yumrepo { 'jenkins':

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "gutocarvalho-jenkins",
   "version": "1.0.0",
   "author": "gutocarvalho",
-  "summary": "This module will install the latest jenkins v2",
+  "summary": "This module will install the latest Jenkins v2",
   "license": "Apache-2.0",
   "source": "https://github.com/gutocarvalho/puppet-jenkins",
   "project_page": "https://github.com/gutocarvalho/puppet-jenkins",
@@ -48,6 +48,12 @@
     },
     {
       "name":"puppet/archive"
+    },
+    {
+      "name":"crayfishx/ldconfig"
+    },
+    {
+      "name":"stm/file_capability"
     }
   ],
   "pdk-version": "1.2.1",


### PR DESCRIPTION
This patch allows the Jenkins Java process to bind in reserved ports
(80, 443) using GNU/Linux kernel capabilities.

Now the default ports (8080 for HTTP, 443 for HTTPS) are declared.

It also remove redundant Augeas cumbersome configuration.