### PR TITLE
Fixes the Jenkins service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,18 @@
 class jenkins::service {
 
+  $requirements = $jenkins::use_reserved_ports ? {
+    true    => Exec['ldconfig::exec'],
+    default => undef,
+  }
+
   service { 'jenkins':
     ensure     => running,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
+    require    => [
+      $requirements,
+    ]
   }
 
 }


### PR DESCRIPTION
This changes fix the service, that should be started only after the LD_LIBRARY_PATH update, if the reserved ports are in use. Without this change the service startup will fail if the LD_LIBRARY_PATH config is delayed.